### PR TITLE
Close the dialog when pressing the ESC key

### DIFF
--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -84,6 +84,16 @@ class KiCadToJLCForm(wx.Frame):
 
         self.Centre(wx.BOTH)
 
+        # Bind the ESC key event to a handler
+        self.Bind(wx.EVT_CHAR_HOOK, self.onKey)
+
+    # Close the dialog when pressing the ESC key
+    def onKey(self, event):
+        if event.GetKeyCode() == wx.WXK_ESCAPE:
+            self.Close(True)
+        else:
+            event.Skip()
+
 
     def onGenerateButtonClick(self, event):
         options = dict()


### PR DESCRIPTION
Many dialogs in KiCAD can be closed using the ESC key (Board Setup, Page Settings, DRC etc).

It's a small modification to make the Fabrication Toolkit dialog's behaviour more in phase with other KiCad's dialogs.